### PR TITLE
Fix InProgress display to show 'In Progress' with space

### DIFF
--- a/packages/web/src/components/TaskList.tsx
+++ b/packages/web/src/components/TaskList.tsx
@@ -220,6 +220,15 @@ export default function TaskList({ tasks, loading, onTaskUpdate }: TaskListProps
     }
   };
 
+  const formatStatusDisplay = (status: TaskStatus) => {
+    switch (status) {
+      case 'InProgress':
+        return 'In Progress';
+      default:
+        return status;
+    }
+  };
+
   const isOverdue = (task: Task) => {
     if (!task.dueAt) return false;
     return isAfter(new Date(), new Date(task.dueAt));
@@ -272,7 +281,7 @@ export default function TaskList({ tasks, loading, onTaskUpdate }: TaskListProps
                   <div className="flex items-center space-x-2 mt-1">
                     {getStatusIcon(task.status)}
                     <span className={`badge ${getStatusColor(task.status)}`}>
-                      {task.status}
+                      {formatStatusDisplay(task.status)}
                     </span>
                   </div>
 


### PR DESCRIPTION
This PR fixes the display issue where tasks with status 'InProgress' were showing as 'InProgress' instead of 'In Progress' in the task list.

## Changes
- Added a  function to the TaskList component
- Updated the status display to use this function for proper formatting
- Only affects the display - the underlying data structure remains unchanged

## Testing
The change only affects the display layer and doesn't modify any business logic or data structures.