### PR TITLE
Add clickable links to task dependencies and blocking tasks

### DIFF
--- a/packages/web/src/components/DependencyManager.tsx
+++ b/packages/web/src/components/DependencyManager.tsx
@@ -9,9 +9,10 @@ interface DependencyManagerProps {
   onTaskUpdate: () => void;
   isExpanded?: boolean;
   onToggle?: () => void;
+  onEditTask?: (task: Task) => void;
 }
 
-export default function DependencyManager({ task, onTaskUpdate, isExpanded = false, onToggle }: DependencyManagerProps) {
+export default function DependencyManager({ task, onTaskUpdate, isExpanded = false, onToggle, onEditTask }: DependencyManagerProps) {
   const [dependencies, setDependencies] = useState<DependencyWithTask[]>([]);
   const [blockingTasks, setBlockingTasks] = useState<DependencyWithTask[]>([]);
   const [allTasks, setAllTasks] = useState<Task[]>([]);
@@ -209,7 +210,11 @@ export default function DependencyManager({ task, onTaskUpdate, isExpanded = fal
 
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center space-x-2">
-                      <h4 className="text-sm font-medium text-gray-900 truncate">
+                      <h4 
+                        className={`text-sm font-medium text-gray-900 truncate ${onEditTask ? 'cursor-pointer hover:text-primary-600 hover:underline' : ''}`}
+                        onClick={() => onEditTask && onEditTask(dependency.blockerTask)}
+                        title={onEditTask ? 'Click to edit this task' : undefined}
+                      >
                         {dependency.blockerTask.title}
                       </h4>
                       <span className={`badge badge-sm ${getPriorityColor(dependency.blockerTask.priority)}`}>
@@ -272,7 +277,11 @@ export default function DependencyManager({ task, onTaskUpdate, isExpanded = fal
 
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center space-x-2">
-                      <h4 className="text-sm font-medium text-gray-900 truncate">
+                      <h4 
+                        className={`text-sm font-medium text-gray-900 truncate ${onEditTask ? 'cursor-pointer hover:text-primary-600 hover:underline' : ''}`}
+                        onClick={() => onEditTask && onEditTask(blockingTask.dependentTask)}
+                        title={onEditTask ? 'Click to edit this task' : undefined}
+                      >
                         {blockingTask.dependentTask.title}
                       </h4>
                       <span className={`badge badge-sm ${getPriorityColor(blockingTask.dependentTask.priority)}`}>

--- a/packages/web/src/components/TaskList.tsx
+++ b/packages/web/src/components/TaskList.tsx
@@ -348,6 +348,7 @@ export default function TaskList({ tasks, loading, onTaskUpdate }: TaskListProps
                             onTaskUpdate={onTaskUpdate}
                             isExpanded={true}
                             onToggle={() => toggleDependencies(task.id)}
+                            onEditTask={setEditingTask}
                           />
                         )}
                       </div>


### PR DESCRIPTION
## Summary

This PR adds clickable links to task titles in the dependencies and blocking tasks sections, allowing users to easily jump to and edit those tasks.

## Changes

- **DependencyManager.tsx**: Added  prop and made task titles clickable
  - Added hover effects and cursor pointer for better UX
  - Added tooltips to indicate clickable functionality
  - Made both dependencies and blocking tasks clickable

- **TaskList.tsx**: Passed  function to DependencyManager
  - This enables the edit modal to open when clicking on dependency tasks

## User Experience

Users can now:
- Click on any task title in the dependencies section to open its edit modal
- Click on any task title in the blocking tasks section to open its edit modal
- Easily navigate between related tasks without having to search for them

## Testing

- ✅ Application builds successfully
- ✅ TypeScript compilation passes
- ✅ No breaking changes to existing functionality
- ✅ Maintains existing styling and layout

## Screenshots

The task titles now show hover effects and cursor pointer when hovering, indicating they are clickable.