### PR TITLE
Fix: Exclude completed tasks from smart task queue

### DIFF
--- a/packages/api/src/services/taskService.ts
+++ b/packages/api/src/services/taskService.ts
@@ -1157,8 +1157,13 @@ export class TaskService {
 
     const now = new Date();
 
-    // Get all tasks for ordering algorithm
+    // Get all non-completed tasks for ordering algorithm
     const tasks = await prisma.task.findMany({
+      where: {
+        status: {
+          notIn: ['Completed']
+        }
+      },
       orderBy: [
         { priority: 'desc' },
         { dueAt: 'asc' },


### PR DESCRIPTION
## Summary

This PR fixes an issue where completed tasks were being included in the smart task queue, which cluttered the user interface with non-actionable items.

## Changes Made

- Modified the  method in  to filter out tasks with status 'Completed'
- Updated the Prisma query to use  for better clarity and maintainability
- Added a  clause to the task fetching query to exclude completed tasks

## Testing

- Created test tasks with different statuses (Todo, Completed, Todo)
- Verified that completed tasks are no longer included in the smart task queue
- Confirmed that non-completed tasks are still properly included and ordered

## Impact

- Improves user experience by reducing clutter in the task ordering interface
- Ensures the smart task queue only contains actionable tasks
- Maintains all existing functionality for task ordering and scoring

## Files Changed

-  - Added filtering logic to exclude completed tasks