### PR TITLE
Fix UI issues and completed tasks toggle button

### DIFF
--- a/packages/web/src/app/__tests__/page.test.tsx
+++ b/packages/web/src/app/__tests__/page.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HomePage from '../page';
+
+// Mock the API calls
+vi.mock('@/lib/api', () => ({
+  fetchTasks: vi.fn(),
+}));
+
+// Mock the components
+vi.mock('@/components/TaskList', () => ({
+  default: ({ tasks }: { tasks: any[] }) => (
+    <div data-testid="task-list">
+      {tasks.map(task => (
+        <div key={task.id} data-testid={`task-${task.id}`}>
+          {task.title} - {task.status}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/CreateTaskModal', () => ({
+  default: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="create-modal">
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/LabelMultiSelect', () => ({
+  default: () => <div data-testid="label-select" />,
+}));
+
+describe('HomePage - Completed Tasks Toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Mock fetch to return some test data
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: '1',
+            title: 'Task 1',
+            status: 'Todo',
+            priority: 'Medium',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            parentId: null,
+            children: [],
+            dependencies: [],
+            taskLabels: [],
+          },
+          {
+            id: '2',
+            title: 'Task 2',
+            status: 'Completed',
+            priority: 'High',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            parentId: null,
+            children: [],
+            dependencies: [],
+            taskLabels: [],
+          },
+        ],
+        pagination: {
+          total: 2,
+          totalPages: 1,
+          page: 1,
+        },
+      }),
+    });
+  });
+
+  it('should show "Hide Completed" when completed tasks are visible', async () => {
+    render(<HomePage />);
+    
+    // Wait for the page to load
+    await screen.findByTestId('task-list');
+    
+    // The button should show "Hide Completed" when showCompletedTasks is true (default)
+    const toggleButton = screen.getByText('Hide Completed');
+    expect(toggleButton).toBeInTheDocument();
+    
+    // Should show both tasks (including completed)
+    expect(screen.getByTestId('task-1')).toBeInTheDocument();
+    expect(screen.getByTestId('task-2')).toBeInTheDocument();
+  });
+
+  it('should show "Show All" when completed tasks are hidden', async () => {
+    render(<HomePage />);
+    
+    // Wait for the page to load
+    await screen.findByTestId('task-list');
+    
+    // Click the toggle button to hide completed tasks
+    const toggleButton = screen.getByText('Hide Completed');
+    await userEvent.click(toggleButton);
+    
+    // The button should now show "Show All"
+    expect(screen.getByText('Show All')).toBeInTheDocument();
+    
+    // Should only show non-completed tasks
+    expect(screen.getByTestId('task-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-2')).not.toBeInTheDocument();
+  });
+
+  it('should toggle between states correctly', async () => {
+    render(<HomePage />);
+    
+    // Wait for the page to load
+    await screen.findByTestId('task-list');
+    
+    // Initially should show "Hide Completed"
+    expect(screen.getByText('Hide Completed')).toBeInTheDocument();
+    
+    // Click to hide completed tasks
+    await userEvent.click(screen.getByText('Hide Completed'));
+    expect(screen.getByText('Show All')).toBeInTheDocument();
+    
+    // Click to show all tasks again
+    await userEvent.click(screen.getByText('Show All'));
+    expect(screen.getByText('Hide Completed')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -5,7 +5,7 @@ import { Plus, Search, Calendar, Clock, AlertTriangle, CheckCircle, Circle, Eye,
 import TaskList from '@/components/TaskList';
 import CreateTaskModal from '@/components/CreateTaskModal';
 import LabelMultiSelect from '@/components/LabelMultiSelect';
-import { Task, TaskStatus, Priority } from '@/types';
+import { Task } from '@/types';
 
 export default function HomePage() {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -177,48 +177,7 @@ export default function HomePage() {
     fetchTasks(currentPageRef.current, false);
   }, []); // No dependencies needed since we use refs
 
-  const _getStatusIcon = (status: TaskStatus) => {
-    switch (status) {
-      case 'Completed':
-        return <CheckCircle className="w-4 h-4 text-success-600" />;
-      case 'InProgress':
-        return <Clock className="w-4 h-4 text-primary-600" />;
-      case 'Blocked':
-        return <AlertTriangle className="w-4 h-4 text-danger-600" />;
-      default:
-        return <Circle className="w-4 h-4 text-gray-400" />;
-    }
-  };
 
-  const _getPriorityColor = (priority: Priority) => {
-    switch (priority) {
-      case 'High':
-        return 'priority-high';
-      case 'Medium':
-        return 'priority-medium';
-      case 'Low':
-        return 'priority-low';
-      default:
-        return 'priority-medium';
-    }
-  };
-
-  const _getStatusColor = (status: TaskStatus) => {
-    switch (status) {
-      case 'Todo':
-        return 'status-todo';
-      case 'InProgress':
-        return 'status-inprogress';
-      case 'Blocked':
-        return 'status-blocked';
-      case 'Completed':
-        return 'status-completed';
-      case 'Canceled':
-        return 'status-canceled';
-      default:
-        return 'status-todo';
-    }
-  };
 
   // Filter tasks based on showCompletedTasks setting
   const filteredTasks = tasks.filter(task => {
@@ -552,8 +511,8 @@ export default function HomePage() {
                     onClick={() => setShowCompletedTasks(!showCompletedTasks)}
                     className={`btn btn-sm ${showCompletedTasks ? 'btn-primary' : 'btn-secondary'}`}
                   >
-                    {showCompletedTasks ? <Eye className="w-4 h-4 mr-1" /> : <EyeOff className="w-4 h-4 mr-1" />}
-                    {showCompletedTasks ? 'Show All' : 'Hide Completed'}
+                    {showCompletedTasks ? <EyeOff className="w-4 h-4 mr-1" /> : <Eye className="w-4 h-4 mr-1" />}
+                    {showCompletedTasks ? 'Hide Completed' : 'Show All'}
                   </button>
                 </div>
               </div>

--- a/packages/web/src/components/CreateTaskModal.tsx
+++ b/packages/web/src/components/CreateTaskModal.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { X, Clock, AlertTriangle } from 'lucide-react';
-import { TaskStatus, Priority, CreateTaskInput, Task, RecurrencePattern } from '@/types';
+import { CreateTaskInput, Task, RecurrencePattern } from '@/types';
 import DateTimePicker from './DateTimePicker';
 import LabelManager from './LabelManager';
 import RecurrencePatternSelector from './RecurrencePatternSelector';
@@ -312,10 +312,6 @@ export default function CreateTaskModal({ onClose, onSubmit, parentTaskId }: Cre
               Parent Task
             </label>
             <div className="space-y-2">
-              {/* Debug info - remove after testing */}
-              <div className="text-xs text-gray-500 mb-2">
-                Debug: Form parentId = "{watch('parentId')}", Prop parentTaskId = "{parentTaskId}"
-              </div>
               {watch('parentId') ? (
                 <div className="flex items-center justify-between p-3 bg-primary-50 border border-primary-200 rounded-lg">
                   <div>
@@ -421,6 +417,8 @@ export default function CreateTaskModal({ onClose, onSubmit, parentTaskId }: Cre
               selectedLabels={selectedLabels}
               onLabelsChange={setSelectedLabels}
               showCreateButton={false}
+              showHeader={false}
+              showEditButtons={false}
             />
           </div>
 

--- a/packages/web/src/components/EditTaskModal.tsx
+++ b/packages/web/src/components/EditTaskModal.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { X, Clock, AlertTriangle } from 'lucide-react';
-import { Task, TaskStatus, Priority, UpdateTaskInput, RecurrencePattern } from '@/types';
+import { Task, UpdateTaskInput, RecurrencePattern } from '@/types';
 import DateTimePicker from './DateTimePicker';
 import LabelManager from './LabelManager';
 import RecurrencePatternSelector from './RecurrencePatternSelector';
@@ -69,7 +69,6 @@ export default function EditTaskModal({ task, onClose, onSubmit, onDelete }: Edi
     register,
     handleSubmit,
     formState: { errors },
-    reset,
     setValue,
     watch,
   } = useForm<UpdateTaskFormData>({
@@ -245,6 +244,7 @@ export default function EditTaskModal({ task, onClose, onSubmit, onDelete }: Edi
               onLabelsChange={setSelectedLabels}
               showCreateButton={false}
               showHeader={false}
+              showEditButtons={false}
             />
           </div>
 

--- a/packages/web/src/components/LabelManager.tsx
+++ b/packages/web/src/components/LabelManager.tsx
@@ -8,13 +8,15 @@ interface LabelManagerProps {
   onLabelsChange?: (labelIds: string[]) => void;
   showCreateButton?: boolean;
   showHeader?: boolean;
+  showEditButtons?: boolean;
 }
 
 export default function LabelManager({ 
   selectedLabels = [], 
   onLabelsChange,
   showCreateButton = true,
-  showHeader = true
+  showHeader = true,
+  showEditButtons = true
 }: LabelManagerProps) {
   const [labels, setLabels] = useState<Label[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -163,20 +165,22 @@ export default function LabelManager({
                 />
               )}
             </div>
-            <div className="flex space-x-1">
-              <button
-                onClick={() => openEditModal(label)}
-                className="px-2 py-1 text-xs bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
-              >
-                Edit
-              </button>
-              <button
-                onClick={() => handleDeleteLabel(label.id)}
-                className="px-2 py-1 text-xs bg-red-200 text-red-700 rounded hover:bg-red-300"
-              >
-                Delete
-              </button>
-            </div>
+            {showEditButtons && (
+              <div className="flex space-x-1">
+                <button
+                  onClick={() => openEditModal(label)}
+                  className="px-2 py-1 text-xs bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => handleDeleteLabel(label.id)}
+                  className="px-2 py-1 text-xs bg-red-200 text-red-700 rounded hover:bg-red-300"
+                >
+                  Delete
+                </button>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/packages/web/src/components/__tests__/LabelManager.test.tsx
+++ b/packages/web/src/components/__tests__/LabelManager.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LabelManager from '../LabelManager';
+
+// Mock the fetch API
+global.fetch = vi.fn();
+
+const mockLabels = [
+  {
+    id: '1',
+    name: 'Bug',
+    colour: '#FF0000',
+    description: 'Bug label',
+  },
+  {
+    id: '2',
+    name: 'Feature',
+    colour: '#00FF00',
+    description: 'Feature label',
+  },
+];
+
+describe('LabelManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: mockLabels }),
+    });
+  });
+
+  it('should show edit buttons by default', async () => {
+    render(<LabelManager />);
+    
+    // Wait for labels to load
+    await screen.findByText('Bug');
+    
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('should hide edit buttons when showEditButtons is false', async () => {
+    render(<LabelManager showEditButtons={false} />);
+    
+    // Wait for labels to load
+    await screen.findByText('Bug');
+    
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+  });
+
+  it('should show header by default', async () => {
+    render(<LabelManager />);
+    
+    expect(screen.getByText('Labels')).toBeInTheDocument();
+  });
+
+  it('should hide header when showHeader is false', async () => {
+    render(<LabelManager showHeader={false} />);
+    
+    expect(screen.queryByText('Labels')).not.toBeInTheDocument();
+  });
+
+  it('should show create button by default', async () => {
+    render(<LabelManager />);
+    
+    expect(screen.getByText('Create Label')).toBeInTheDocument();
+  });
+
+  it('should hide create button when showCreateButton is false', async () => {
+    render(<LabelManager showCreateButton={false} />);
+    
+    expect(screen.queryByText('Create Label')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Fix labels list on subtask create to not have duplicate titles
- Remove debugging display from subtasks
- Hide edit/delete buttons for labels in task create/edit modals
- Fix completed tasks toggle button display states (text and icons were backwards)
- Add comprehensive tests for LabelManager component
- Add tests for completed tasks toggle functionality
- Clean up unused imports and functions to fix linter errors

The toggle button now correctly shows:
- 'Hide Completed' with EyeOff icon when showing all tasks
- 'Show All' with Eye icon when hiding completed tasks